### PR TITLE
chore: fix mocha lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
         'mocha/no-identical-title': 'off',
         'mocha/no-nested-tests': 'off',
         'mocha/no-pending-tests': 'off',
+        'mocha/no-exclusive-tests': 'error',
 
         'faltest/chai-webdriver-eventually': 'error',
         'faltest/mocha-roles-only': 'error',

--- a/packages/page-objects/test/acceptance/api-verification-test.js
+++ b/packages/page-objects/test/acceptance/api-verification-test.js
@@ -14,7 +14,7 @@ const tmpDir = promisify(require('tmp').dir);
 const writeFile = promisify(require('fs').writeFile);
 const path = require('path');
 
-describe.only(function() {
+describe(function() {
   setUpWebDriver.call(this, {
     shareWebdriver: true,
     keepBrowserOpen: true,

--- a/packages/remote/test/acceptance/redact-password-test.js
+++ b/packages/remote/test/acceptance/redact-password-test.js
@@ -8,7 +8,7 @@ const debug = require('../../src/debug');
 const sinon = require('sinon');
 const Server = require('../../../../helpers/server');
 
-describe.only(function() {
+describe(function() {
   test('same log level', 'info');
   test('more permissive log level', 'trace');
 });


### PR DESCRIPTION
why oh why is no-exclusive-tests set to warn?