### PR TITLE
chore: update `connectionRetryTimeout` comment

### DIFF
--- a/packages/remote/src/index.js
+++ b/packages/remote/src/index.js
@@ -283,8 +283,8 @@ function startBrowser(options = {}) {
         // this is only needed for geckodriver because
         // it takes a while to boot up and doesn't notify
         // you via console output
-        // `connectionRetryTimeout` would be a better option,
-        // but it doesn't work (unimplemented)
+        // `connectionRetryTimeout` seems like it would be a better option,
+        // but the connections fail immediately and the timeout isn't even hit
         connectionRetryCount,
       });
     } catch (err) {


### PR DESCRIPTION
now that https://github.com/webdriverio/webdriverio/pull/4906 is out and it doesn't work as intended