### PR TITLE
fix: missing return statement in getAttribute

### DIFF
--- a/packages/page-objects/src/element.js
+++ b/packages/page-objects/src/element.js
@@ -68,7 +68,7 @@ class Element extends BaseElement {
   }
 
   async getAttribute() {
-    await this._browser.getAttribute(this._selector, ...arguments);
+    return await this._browser.getAttribute(this._selector, ...arguments);
   }
 }
 

--- a/packages/page-objects/test/acceptance/api-verification-test.js
+++ b/packages/page-objects/test/acceptance/api-verification-test.js
@@ -202,4 +202,21 @@ describe(function() {
     await expect(this.page.foo.waitForDestroy())
       .to.eventually.be.fulfilled;
   });
+
+  it(Element.prototype.getAttribute, async function() {
+    await this.writeFixture('index.html', `
+      <div class="foo">
+    `);
+
+    this.page = this.createPage(class extends BasePageObject {
+      get foo() {
+        return this._create('.foo');
+      }
+    });
+
+    await this.open('index.html');
+
+    await expect(this.page.foo.getAttribute('class'))
+      .to.eventually.equal('foo');
+  });
 });


### PR DESCRIPTION
The `getAttribute` method in `Element` is missing a return statement.