### PR TITLE
fix: rename `_extendUnscopedMany` to `_extendManyUnscoped`

### DIFF
--- a/packages/page-objects/src/base-page-object.js
+++ b/packages/page-objects/src/base-page-object.js
@@ -172,6 +172,6 @@ function applyProperties(extraProperties, unassigned, assigned) {
 
 BasePageObject.prototype.extend = extend;
 BasePageObject.prototype._extendUnscoped = extend;
-BasePageObject.prototype._extendUnscopedMany = extend;
+BasePageObject.prototype._extendManyUnscoped = extend;
 
 module.exports = BasePageObject;


### PR DESCRIPTION
to match `_createManyUnscoped`

Closes #279