### PR TITLE
feat: optimize failure artifacts

### DIFF
--- a/examples/full-suite/helpers/mocha.js
+++ b/examples/full-suite/helpers/mocha.js
@@ -5,7 +5,6 @@ const { setUpWebDriver } = require('@faltest/lifecycle');
 const {
   createRolesHelper,
   createFlaggedTest,
-  createFailureArtifactsHelpers,
 } = require('@faltest/mocha');
 
 const roles = createRolesHelper(global.describe, role => config.get('roles').get(role));
@@ -14,17 +13,9 @@ const featureFlags = [];
 
 const it = createFlaggedTest(global.it, featureFlags);
 
-const hooks = createFailureArtifactsHelpers({
-  before: global.before,
-  beforeEach: global.beforeEach,
-  it,
-  afterEach: global.afterEach,
-  after: global.after,
-});
-
 module.exports = {
   setUpWebDriver,
   roles,
   featureFlags,
-  ...hooks,
+  it,
 };

--- a/packages/mocha/src/failure-artifacts.js
+++ b/packages/mocha/src/failure-artifacts.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { wrap } = require('./mocha');
 const path = require('path');
 const fs = require('fs');
 const { promisify } = require('util');
@@ -8,94 +7,48 @@ const writeFile = promisify(fs.writeFile);
 const mkdir = promisify(fs.mkdir);
 const filenamify = require('filenamify');
 
-function failureArtifacts(outputDir) {
-  return test => {
-    return function failureArtifacts(...args) {
-      function buildTitle(test) {
-        let parts = [];
+function buildTitle(test) {
+  let parts = [];
 
-        while (test) {
-          if (test.title) {
-            parts.unshift(test.title);
-          }
+  while (test) {
+    if (test.title) {
+      parts.unshift(test.title);
+    }
 
-          test = test.parent;
-        }
-
-        let title = parts.join(' ');
-
-        // Tests with / in the name are bad.
-        title = filenamify(title);
-
-        return title;
-      }
-
-      let callback = args.pop();
-
-      return test(...args, async function() {
-        try {
-          return await callback.apply(this, arguments);
-        } catch (err) {
-          if (this.browser) {
-            let title = buildTitle(this.test);
-            try {
-              await mkdir(outputDir);
-            } catch (err) {}
-
-            let element = await this.browser.$('body');
-
-            let screenshot = await this.browser._browser.takeElementScreenshot(element.elementId);
-            let screenshotPath = path.join(outputDir, `${title}.png`);
-            await writeFile(screenshotPath, screenshot, 'base64');
-
-            let html = await element.getHTML();
-            let htmlPath = path.join(outputDir, `${title}.html`);
-            await writeFile(htmlPath, html);
-
-            let logTypes = await this.browser._browser.getLogTypes();
-            for (let logType of logTypes) {
-              let logs = await this.browser._browser.getLogs(logType);
-              let logsText = JSON.stringify(logs, null, 2);
-              let logPath = path.join(outputDir, `${title}.${logType}.txt`);
-              await writeFile(logPath, logsText);
-            }
-          }
-          throw err;
-        }
-      });
-    };
-  };
-}
-
-
-function create(mocha, {
-  enabled = process.env.WEBDRIVER_FAILURE_ARTIFACTS === 'true',
-  outputDir = process.env.WEBDRIVER_FAILURE_ARTIFACTS_OUTPUT_DIR,
-} = {}) {
-  if (enabled && !outputDir) {
-    throw new Error('You must supply an output dir.');
+    test = test.parent;
   }
 
-  let __failureArtifacts = failureArtifacts(outputDir);
+  let title = parts.join(' ');
 
-  return [
-    'before',
-    'beforeEach',
-    'it',
-    'afterEach',
-    'after',
-  ].reduce((hooks, lifecycle) => {
-    if (mocha[lifecycle]) {
-      if (enabled) {
-        hooks[lifecycle] = wrap(mocha[lifecycle], __failureArtifacts);
-      } else {
-        hooks[lifecycle] = mocha[lifecycle];
-      }
-    }
-    return hooks;
-  }, {});
+  // Tests with / in the name are bad.
+  title = filenamify(title);
+
+  return title;
 }
 
-module.exports = {
-  create,
-};
+async function failureArtifacts(outputDir) {
+  let title = buildTitle(this.currentTest);
+  try {
+    await mkdir(outputDir);
+  } catch (err) {}
+
+  let element = await this.browser.$('body');
+
+  let screenshot = await this.browser._browser.takeElementScreenshot(element.elementId);
+  let screenshotPath = path.join(outputDir, `${title}.png`);
+  await writeFile(screenshotPath, screenshot, 'base64');
+
+  let html = await element.getHTML();
+  let htmlPath = path.join(outputDir, `${title}.html`);
+  await writeFile(htmlPath, html);
+
+  let logTypes = await this.browser._browser.getLogTypes();
+  for (let logType of logTypes) {
+    let logs = await this.browser._browser.getLogs(logType);
+    let logsText = JSON.stringify(logs, null, 2);
+    let logPath = path.join(outputDir, `${title}.${logType}.txt`);
+    await writeFile(logPath, logsText);
+  }
+}
+
+module.exports = failureArtifacts;

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -79,5 +79,5 @@ module.exports = {
   runTests,
   createRolesHelper: require('./role').create,
   createFlaggedTest: require('./flag').create,
-  createFailureArtifactsHelpers: require('./failure-artifacts').create,
+  failureArtifacts: require('./failure-artifacts'),
 };

--- a/packages/mocha/test/fixtures/failure-artifacts-test.js
+++ b/packages/mocha/test/fixtures/failure-artifacts-test.js
@@ -1,10 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const { createFailureArtifactsHelpers } = require('../../src');
 const { setUpWebDriver } = require('../../../lifecycle');
-
-Object.assign(global, createFailureArtifactsHelpers(global));
 
 describe('failure artifacts', function() {
   setUpWebDriver.call(this);


### PR DESCRIPTION
We can remove the try/catch override for every hook by using `this.currentTest.state` in `afterEach` instead.

BREAKING CHANGE: `createFailureArtifacts` was removed because it is no longer necessary.