### PR TITLE
fix: don't create failure artifacts for `this.skip` tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
         'mocha/no-nested-tests': 'off',
         'mocha/no-pending-tests': 'off',
         'mocha/no-exclusive-tests': 'error',
+        'mocha/no-skipped-tests': 'error',
 
         'faltest/chai-webdriver-eventually': 'error',
         'faltest/mocha-roles-only': 'error',

--- a/packages/lifecycle/src/index.js
+++ b/packages/lifecycle/src/index.js
@@ -237,8 +237,19 @@ async function setUpWebDriverAfterEach(options) {
     }
   }
 
-  // handle 'failed' and `undefined` if it happens in `beforeEach`
-  if (this.currentTest.state !== 'passed') {
+  // success:
+  //   state: `'passed'`
+  //   pending: `false`
+  // failure in `it`:
+  //   state: `'failed'`
+  //   pending: `false`
+  // failure in `beforeEach`:
+  //   state: `undefined`
+  //   pending: `false`
+  // `this.skip`:
+  //   state: `undefined`
+  //   pending: `true`
+  if (this.currentTest.state !== 'passed' && !this.currentTest.pending) {
     if (options.failureArtifactsEnabled) {
       await mocha.failureArtifacts.call(this, options.failureArtifactsOutputDir);
     }

--- a/packages/mocha/test/acceptance/index-test.js
+++ b/packages/mocha/test/acceptance/index-test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const clearModule = require('clear-module');
 const { runTests } = require('../../src');
 const { promisify } = require('util');
+const { afterEach } = require('mocha');
 const tmpDir = promisify(require('tmp').dir);
 
 describe(function() {
@@ -217,6 +218,31 @@ describe(function() {
 
         expect(stats.tests).to.equal(1);
         expect(stats.passes).to.equal(1);
+      });
+
+      it('doesn\'t make artifacts on it.skip', async function() {
+        let stats = await runTests({
+          globs,
+          filter: 'it it\\.skip$',
+        });
+
+        expect(this.outputDir).to.be.a.directory().and.empty;
+
+        expect(stats.tests).to.equal(1);
+        expect(stats.pending).to.equal(1);
+      });
+
+      it('doesn\'t make artifacts on this.skip', async function() {
+        this.skip();
+        let stats = await runTests({
+          globs,
+          filter: 'it this\\.skip$',
+        });
+
+        expect(this.outputDir).to.be.a.directory().and.empty;
+
+        expect(stats.tests).to.equal(1);
+        expect(stats.pending).to.equal(1);
       });
 
       it('handles errors in beforeEach', async function() {

--- a/packages/mocha/test/fixtures/failure-artifacts-test.js
+++ b/packages/mocha/test/fixtures/failure-artifacts-test.js
@@ -14,6 +14,15 @@ describe('failure artifacts', function() {
     it('success', function() {
       assert.ok(true);
     });
+
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip('it.skip', function() {
+      assert.ok(false);
+    });
+
+    it('this.skip', function() {
+      this.skip();
+    });
   });
 
   describe('beforeEach', function() {


### PR DESCRIPTION
Fixes #354