### PR TITLE
fix: correctly handle failure artifacts in `before` and `after`

### DIFF
--- a/packages/mocha/src/failure-artifacts.js
+++ b/packages/mocha/src/failure-artifacts.js
@@ -28,6 +28,12 @@ function buildTitle(test) {
 }
 
 async function failureArtifacts(outputDir) {
+  // If an error occurs in `before` or `beforeEach`,
+  // there's a change the browser has not been initialized yet.
+  if (!this.browser) {
+    return;
+  }
+
   let title = buildTitle(this.currentTest);
 
   // once node 10.12.0

--- a/packages/mocha/test/acceptance/index-test.js
+++ b/packages/mocha/test/acceptance/index-test.js
@@ -195,13 +195,13 @@ describe(function() {
       it('works', async function() {
         let stats = await runTests({
           globs,
-          filter: 'it failure$',
+          filter: 'it normal failure$',
         });
 
-        expect(path.join(this.outputDir, 'failure artifacts it failure.png')).to.be.a.file();
-        expect(path.join(this.outputDir, 'failure artifacts it failure.html')).to.be.a.file();
-        expect(path.join(this.outputDir, 'failure artifacts it failure.browser.txt')).to.be.a.file();
-        expect(path.join(this.outputDir, 'failure artifacts it failure.driver.txt')).to.be.a.file();
+        expect(path.join(this.outputDir, 'failure artifacts it normal failure.png')).to.be.a.file();
+        expect(path.join(this.outputDir, 'failure artifacts it normal failure.html')).to.be.a.file();
+        expect(path.join(this.outputDir, 'failure artifacts it normal failure.browser.txt')).to.be.a.file();
+        expect(path.join(this.outputDir, 'failure artifacts it normal failure.driver.txt')).to.be.a.file();
 
         expect(stats.tests).to.equal(1);
         expect(stats.failures).to.equal(1);
@@ -210,7 +210,7 @@ describe(function() {
       it('doesn\'t make artifacts on test success', async function() {
         let stats = await runTests({
           globs,
-          filter: 'it success$',
+          filter: 'it normal success$',
         });
 
         expect(this.outputDir).to.be.a.directory().and.empty;
@@ -222,7 +222,7 @@ describe(function() {
       it('doesn\'t make artifacts on it.skip', async function() {
         let stats = await runTests({
           globs,
-          filter: 'it it\\.skip$',
+          filter: 'it normal it\\.skip$',
         });
 
         expect(this.outputDir).to.be.a.directory().and.empty;
@@ -234,13 +234,25 @@ describe(function() {
       it('doesn\'t make artifacts on this.skip', async function() {
         let stats = await runTests({
           globs,
-          filter: 'it this\\.skip$',
+          filter: 'it normal this\\.skip$',
         });
 
         expect(this.outputDir).to.be.a.directory().and.empty;
 
         expect(stats.tests).to.equal(1);
         expect(stats.pending).to.equal(1);
+      });
+
+      it('ignores last test in `after`', async function() {
+        let stats = await runTests({
+          globs,
+          filter: 'it `after` order success$',
+        });
+
+        expect(this.outputDir).to.be.a.directory().and.empty;
+
+        expect(stats.tests).to.equal(1);
+        expect(stats.passes).to.equal(1);
       });
 
       it('handles errors in beforeEach', async function() {
@@ -253,6 +265,33 @@ describe(function() {
         expect(path.join(this.outputDir, 'failure artifacts beforeEach failure.html')).to.be.a.file();
         expect(path.join(this.outputDir, 'failure artifacts beforeEach failure.browser.txt')).to.be.a.file();
         expect(path.join(this.outputDir, 'failure artifacts beforeEach failure.driver.txt')).to.be.a.file();
+
+        expect(stats.tests).to.equal(0);
+        expect(stats.failures).to.equal(1);
+      });
+
+      it('handles errors in before', async function() {
+        let stats = await runTests({
+          globs,
+          filter: 'before with browser failure$',
+        });
+
+        expect(path.join(this.outputDir, 'failure artifacts before with browser failure.png')).to.be.a.file();
+        expect(path.join(this.outputDir, 'failure artifacts before with browser failure.html')).to.be.a.file();
+        expect(path.join(this.outputDir, 'failure artifacts before with browser failure.browser.txt')).to.be.a.file();
+        expect(path.join(this.outputDir, 'failure artifacts before with browser failure.driver.txt')).to.be.a.file();
+
+        expect(stats.tests).to.equal(0);
+        expect(stats.failures).to.equal(1);
+      });
+
+      it('doesn\'t make artifacts if no browser', async function() {
+        let stats = await runTests({
+          globs,
+          filter: 'before without browser failure$',
+        });
+
+        expect(this.outputDir).to.be.a.directory().and.empty;
 
         expect(stats.tests).to.equal(0);
         expect(stats.failures).to.equal(1);

--- a/packages/mocha/test/fixtures/failure-artifacts-test.js
+++ b/packages/mocha/test/fixtures/failure-artifacts-test.js
@@ -4,32 +4,75 @@ const assert = require('assert');
 const { setUpWebDriver } = require('../../../lifecycle');
 
 describe('failure artifacts', function() {
-  setUpWebDriver.call(this);
-
   describe('it', function() {
-    it('failure', function() {
-      assert.ok(false);
+    describe('normal', function() {
+      setUpWebDriver.call(this);
+
+      it('failure', function() {
+        assert.ok(false);
+      });
+
+      it('success', function() {
+        assert.ok(true);
+      });
+
+      // eslint-disable-next-line mocha/no-skipped-tests
+      it.skip('it.skip', function() {
+        assert.ok(false);
+      });
+
+      it('this.skip', function() {
+        this.skip();
+      });
     });
 
-    it('success', function() {
-      assert.ok(true);
-    });
+    describe('`after` order', function() {
+      setUpWebDriver.call(this);
 
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip('it.skip', function() {
-      assert.ok(false);
-    });
+      it('success', function() {
+        assert.ok(true);
+      });
 
-    it('this.skip', function() {
-      this.skip();
+      // `after`'s `currentTest` will be this, ever though
+      // it was filtered out and never run...
+      it('failure', function() {
+        assert.ok(false);
+      });
     });
   });
 
   describe('beforeEach', function() {
+    setUpWebDriver.call(this);
+
     beforeEach(function() {
       assert.ok(false);
     });
 
     it('failure', function() {});
+  });
+
+  describe('before', function() {
+    describe('with browser', function() {
+      setUpWebDriver.call(this, {
+        shareWebdriver: true,
+        keepBrowserOpen: true,
+      });
+
+      before(function() {
+        assert.ok(false);
+      });
+
+      it('failure', function() {});
+    });
+
+    describe('without browser', function() {
+      setUpWebDriver.call(this);
+
+      before(function() {
+        assert.ok(false);
+      });
+
+      it('failure', function() {});
+    });
   });
 });


### PR DESCRIPTION
Right now, errors in `before` are not getting handled.