### PR TITLE
fix: defer accessing mocha hooks until needed

### DIFF
--- a/examples/full-suite/helpers/mocha.js
+++ b/examples/full-suite/helpers/mocha.js
@@ -7,11 +7,11 @@ const {
   createFlaggedTest,
 } = require('@faltest/mocha');
 
-const roles = createRolesHelper(global.describe, role => config.get('roles').get(role));
+const roles = createRolesHelper(global, role => config.get('roles').get(role));
 
 const featureFlags = [];
 
-const it = createFlaggedTest(global.it, featureFlags);
+const it = createFlaggedTest(global, featureFlags);
 
 module.exports = {
   setUpWebDriver,

--- a/packages/mocha/src/flag.js
+++ b/packages/mocha/src/flag.js
@@ -18,7 +18,7 @@ function areAllFlagsPresent(names, total) {
 }
 
 function flaggedTest(total, isDeactivated) {
-  return it => {
+  return mocha => {
     return function flaggedTest(stringOrObject, callback) {
       let name;
       let flags = [];
@@ -33,10 +33,10 @@ function flaggedTest(total, isDeactivated) {
 
       if (!isDeactivated && flags.length) {
         name = formatTitle(name);
-        name += `${it.titleSeparator || titleSeparator}flags: ${flags.join(', ')}`;
+        name += `${mocha.it.titleSeparator || titleSeparator}flags: ${flags.join(', ')}`;
       }
 
-      it(name, async function () {
+      mocha.it(name, async function () {
         if (!isDeactivated && flags.length && !areAllFlagsPresent(flags, total)) {
           this.skip();
           return;
@@ -48,10 +48,10 @@ function flaggedTest(total, isDeactivated) {
   };
 }
 
-function create(it, flags, isDeactivated) {
+function create(mocha, flags, isDeactivated) {
   let _flaggedTest = flaggedTest(flags, isDeactivated);
 
-  let _it = wrap(it, _flaggedTest);
+  let _it = wrap(mocha, 'it', _flaggedTest);
 
   return _it;
 }

--- a/packages/mocha/src/mocha.js
+++ b/packages/mocha/src/mocha.js
@@ -1,13 +1,13 @@
 'use strict';
 
-function wrap(mocha, func) {
-  let _mocha = func(mocha);
-  for (let name of Object.keys(mocha)) {
-    if (typeof mocha[name] === 'function') {
-      _mocha[name] = func(mocha[name]);
+function wrap(mocha, name, func) {
+  let test = func({ [name]() { return mocha[name](...arguments); } });
+  for (let modifier of Object.keys(mocha[name])) {
+    if (typeof mocha[name][modifier] === 'function') {
+      test[modifier] = func({ [name]() { return mocha[name][modifier](...arguments); } });
     }
   }
-  return _mocha;
+  return test;
 }
 
 module.exports = {

--- a/packages/mocha/src/role.js
+++ b/packages/mocha/src/role.js
@@ -6,7 +6,7 @@ const {
 const { wrap } = require('./mocha');
 
 function roles(getRole, getFilePathTitle) {
-  return describe => {
+  return mocha => {
     return function roles(tags, callback) {
       // must be instanced and not inline
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#Finding_successive_matches
@@ -17,8 +17,8 @@ function roles(getRole, getFilePathTitle) {
         for (let matches; matches = regex.exec(tags);) {
           let role = matches[1];
 
-          describe(`#${role}`, function() {
-            before(function() {
+          mocha.describe(`#${role}`, function() {
+            global.before(function() {
               this.role = getRole(role);
             });
 
@@ -36,10 +36,10 @@ function roles(getRole, getFilePathTitle) {
   };
 }
 
-function create(describe, getRole, getFilePathTitle) {
+function create(mocha, getRole, getFilePathTitle) {
   let __roles = roles(getRole, getFilePathTitle);
 
-  let _roles = wrap(describe, __roles);
+  let _roles = wrap(mocha, 'describe', __roles);
 
   return _roles;
 }

--- a/packages/mocha/test/fixtures/flag-test.js
+++ b/packages/mocha/test/fixtures/flag-test.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const { createFlaggedTest } = require('../../src');
 
-global.it = createFlaggedTest(it, ['flag1']);
+const it = createFlaggedTest(global, ['flag1']);
 
 describe('flag', function() {
   it({

--- a/packages/mocha/test/fixtures/role-test.js
+++ b/packages/mocha/test/fixtures/role-test.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const { createRolesHelper } = require('../../src');
 
-const roles = createRolesHelper(describe, role => role);
+const roles = createRolesHelper(global, role => role);
 
 describe('role', function() {
   roles('#role1', function() {


### PR DESCRIPTION
This will prevent `this.test.file` being incorrect based on eagerly calling the real `describe`.

BREAKING CHANGE: The first param of `createRolesHelper` and `createFlaggedTest` has changed to be the object source of the mocha hooks (usually `global`).