### PR TITLE
chore: use null reporter in tests

### DIFF
--- a/packages/mocha/test/acceptance/index-test.js
+++ b/packages/mocha/test/acceptance/index-test.js
@@ -21,6 +21,7 @@ describe(function() {
       this.runTests = async options => {
         return await _runTests({
           globs,
+          reporter: path.join(fixturesPath, 'null-reporter.js'),
           ...options,
         });
       };

--- a/packages/mocha/test/fixtures/null-reporter.js
+++ b/packages/mocha/test/fixtures/null-reporter.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = class {};


### PR DESCRIPTION
to prevent expected failures in logs confusing any real failures