### PR TITLE
chore: get rid of sinon-chai warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "renovate-config-standard": "^2.0.0",
     "serve-static": "^1.14.1",
     "sinon": "^14.0.0",
-    "sinon-chai": "^3.5.0",
+    "sinon-chai": "^3.7.0",
     "stoppable": "^1.1.0",
     "tmp": "0.2.1",
     "yargs-help-output": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5312,10 +5312,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-sinon-chai@^3.5.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.6.0.tgz#25bd59a37ef8990245e085a40f1f79d6bf023b7a"
-  integrity sha512-bk2h+0xyKnmvazAnc7HE5esttqmCerSMcBtuB2PS2T4tG6x8woXAxZeJaOJWD+8reXHngnXn0RtIbfEW9OTHFg==
+sinon-chai@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz#cfb7dec1c50990ed18c153f1840721cf13139783"
+  integrity sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==
 
 sinon@^14.0.0:
   version "14.0.0"


### PR DESCRIPTION
warning " > sinon-chai@3.6.0" has incorrect peer dependency "sinon@>=4.0.0 <11.0.0".