### PR TITLE
fix: kill all remaining webdriver browsers

### DIFF
--- a/packages/remote/src/index.js
+++ b/packages/remote/src/index.js
@@ -93,7 +93,9 @@ async function killOrphans() {
     if (isAboutToBeOrphaned) {
       return true;
     }
-    let isAlreadyOrphaned = browserCmdRegex.test(cmd) && ppid === 1;
+    // This kills any other webdriver browsers that may be in use.
+    // Checking the ppid is inconsistent across OSes.
+    let isAlreadyOrphaned = browserCmdRegex.test(cmd);
     if (isAlreadyOrphaned) {
       return true;
     }


### PR DESCRIPTION
An orphaned webdriver browser would only get its ppid set to 1 in mac. In linux, it would get set to systemd, which is not 1. We can't rely on that number, so instead we just kill any left over browsers spawned by webdriver, even if another theoretical webdriver instance is using them.