### PR TITLE
chore: set CHROMEDRIVER_SKIP_DOWNLOAD in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   DEBUG: "@faltest*,faltest-helpers"
-  DETECT_CHROMEDRIVER_VERSION: true
+  CHROMEDRIVER_SKIP_DOWNLOAD: true
   DETECT_EDGEDRIVER_VERSION: true
 
 jobs:


### PR DESCRIPTION
This is just an optimisation because github agents already have a matching version for Chrome.