### PR TITLE
feat: add attempt count to failure artifacts

### DIFF
--- a/packages/mocha/src/failure-artifacts.js
+++ b/packages/mocha/src/failure-artifacts.js
@@ -8,6 +8,8 @@ const mkdir = promisify(fs.mkdir);
 const debug = require('./debug');
 
 async function buildTitle(test) {
+  let attempt = test.currentRetry() + 1;
+
   let parts = [];
 
   while (test) {
@@ -25,7 +27,7 @@ async function buildTitle(test) {
   // Tests with / in the name are bad.
   title = filenamify(title);
 
-  return title;
+  return `${title}.${attempt}`;
 }
 
 async function failureArtifacts(outputDir) {

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -53,6 +53,10 @@ async function runMocha(mocha, options) {
     });
 
     runner.on(constants.EVENT_TEST_RETRY, (test, err) => {
+      handlePromises(() => {
+        return failureArtifacts.call(test.ctx, options.failureArtifactsOutputDir);
+      });
+
       debug(`Retrying failed test "${test.title}": ${err}`);
     });
 

--- a/packages/mocha/test/fixtures/failure-artifacts-test.js
+++ b/packages/mocha/test/fixtures/failure-artifacts-test.js
@@ -64,6 +64,10 @@ describe('failure artifacts', function() {
         assert.ok(true);
       });
     });
+
+    it('retries', function() {
+      assert.ok(this.test.currentRetry() == 2);
+    });
   });
 
   describe('beforeEach', function() {


### PR DESCRIPTION
currently, failed artifacts are being written only when test fails. Added feature to write failed artifacts on every test retry and added retry attempt count to file names