### PR TITLE
fix: call `waitForPromisesToFlushBetweenTests` in `setUpWebDriverBeforeEach`

### DIFF
--- a/packages/lifecycle/src/index.js
+++ b/packages/lifecycle/src/index.js
@@ -171,6 +171,10 @@ async function setUpWebDriverBefore(options) {
 async function setUpWebDriverBeforeEach(options) {
   await lifecycleEvent('before-each-begin', this, options);
 
+  // The one in `setUpWebDriverAfterEach` is not triggered if the error
+  // happened in `beforeEach` instead of `it`.
+  await waitForPromisesToFlushBetweenTests();
+
   if (!options.keepBrowserOpen && sharedBrowsers) {
     await stopBrowsers(sharedBrowsers);
   }


### PR DESCRIPTION
I saw in some logs the "Writing failure artifact to ..." line in the middle of a getPageSource output. I think it was the failure output of a `beforeEach` running at the same time as the failure output of an `it`. This is because failureArtifacts calls in `beforeEach` don't get awaited until `setUpWebDriverAfterEach`. If we can await the code before then next `it` happens, we may be able to prevent this.