### PR TITLE
feat: store original test error in failure artifact

### DIFF
--- a/packages/mocha/src/failure-artifacts.js
+++ b/packages/mocha/src/failure-artifacts.js
@@ -30,7 +30,7 @@ async function buildTitle(test) {
   return `${title}.${attempt}`;
 }
 
-async function failureArtifacts(outputDir) {
+async function failureArtifacts(error, outputDir) {
   // If an error occurs in `before` or `beforeEach`,
   // there's a chance the browser has not been initialized yet.
   if (!this.browser) {
@@ -62,6 +62,8 @@ async function failureArtifacts(outputDir) {
     let logsText = JSON.stringify(log, null, 2);
     await writeArtifact(`${title}.${logType}.txt`, logsText);
   }
+
+  await writeArtifact(`${title}.error.txt`, error.toString());
 }
 
 async function flush() {

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -45,9 +45,9 @@ async function runMocha(mocha, options) {
       return failAsync(...arguments);
     });
   }
-  async function failAsync(test) {
+  async function failAsync(test, err) {
     if (options.failureArtifacts) {
-      await failureArtifacts.call(test.ctx, options.failureArtifactsOutputDir);
+      await failureArtifacts.call(test.ctx, err, options.failureArtifactsOutputDir);
     }
   }
 
@@ -57,7 +57,7 @@ async function runMocha(mocha, options) {
     });
   }
   async function retryAsync(test, err) {
-    await failAsync(test);
+    await failAsync(test, err);
 
     debug(`Retrying failed test "${test.title}": ${err}`);
   }

--- a/packages/mocha/test/acceptance/index-test.js
+++ b/packages/mocha/test/acceptance/index-test.js
@@ -180,7 +180,7 @@ describe(function() {
               ...options,
             });
           },
-          extensions: ['png', 'html', 'url.txt', 'browser.txt', 'driver.txt'],
+          extensions: ['png', 'html', 'url.txt', 'browser.txt', 'driver.txt', 'error.txt'],
           getFileNames(title, attempt = 1) {
             return this.extensions.map(ext => `failure artifacts ${title}.${attempt}.${ext}`);
           },


### PR DESCRIPTION
When using retries, if the test retries to success, it is hard to find the original test error. You have to view the logs with `DEBUG=@faltest/mocha` and look for `@faltest/mocha Retrying failed test "my test": my error`. This makes it a lot easier to diagnose a flakey error.