### PR TITLE
fix: add `!/packages/` to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 # https://github.com/mysticatea/eslint-plugin-node/issues/77
 *
+!/packages/


### PR DESCRIPTION
Newer NPM versions are ignoring all code in every package.