### PR TITLE
Create alias for "env" called "environment"

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -61,7 +61,7 @@ function initCli({
         default: envs.default,
         description: 'Run against a different data source',
         choices: envs.list,
-		alias: 'environment',
+        alias: 'environment',
       },
       'share-webdriver': {
         type: 'boolean',

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -61,6 +61,7 @@ function initCli({
         default: envs.default,
         description: 'Run against a different data source',
         choices: envs.list,
+		alias: 'environment',
       },
       'share-webdriver': {
         type: 'boolean',


### PR DESCRIPTION
There is a conflict with NX 17+ where --envFile was replaced with --env. This disrupted our faltest e2e tasks, so adding an "environment" alias will workaround this.