### PR TITLE
chore: increase timeout

### DIFF
--- a/packages/mocha/test/acceptance/index-test.js
+++ b/packages/mocha/test/acceptance/index-test.js
@@ -13,7 +13,7 @@ const fixturesPath = path.resolve(__dirname, '../fixtures');
 
 describe(function() {
   describe(_runTests, function() {
-    this.timeout(30e3);
+    this.timeout(60e3);
 
     let globs;
 


### PR DESCRIPTION
Sometimes `works in edge` times out at 30s, or succeeds at 15s.